### PR TITLE
Add new roles views

### DIFF
--- a/RendicionDeGastos/MainApp/templates/MainApp/aprobadas.html
+++ b/RendicionDeGastos/MainApp/templates/MainApp/aprobadas.html
@@ -33,6 +33,8 @@
                         <th>N° Rendición</th>
                         <th>Fecha</th>
                         <th>Monto Aprobado</th>
+                        <th>Comentario</th>
+                        <th>Archivo</th>
                         <th>Estado</th>
                     </tr>
                 </thead>
@@ -42,6 +44,24 @@
                         <td>{{ rendicion.id }}</td>
                         <td>{{ rendicion.fecha_creacion|date:"M d, Y" }}</td>
                         <td>${{ rendicion.total }}</td>
+                        <td>
+                            {% for gasto in rendicion.gastos.all %}
+                                <p>{{ gasto.descripcion }}</p>
+                            {% empty %}
+                                Sin comentarios
+                            {% endfor %}
+                        </td>
+                        <td>
+                            {% for gasto in rendicion.gastos.all %}
+                                {% if gasto.documento_respaldo %}
+                                    <a href="{{ gasto.documento_respaldo.url }}" target="_blank">Ver archivo</a><br>
+                                {% else %}
+                                    Sin archivo<br>
+                                {% endif %}
+                            {% empty %}
+                                Sin archivo
+                            {% endfor %}
+                        </td>
                         <td>{{ rendicion.estado }}</td>
                     </tr>
                     {% endfor %}

--- a/RendicionDeGastos/MainApp/templates/MainApp/estadisticas.html
+++ b/RendicionDeGastos/MainApp/templates/MainApp/estadisticas.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% load static %}
+    <link rel="stylesheet" href="{% static 'MainApp/styles.css' %}">
+    <title>Estadísticas</title>
+</head>
+<body>
+    <header class="header">
+        <div class="logo">
+            <a href="{% url 'index' %}">INICIO</a>
+        </div>
+        <ul class="nav-links">
+            <li><a href="#">Usuario</a></li>
+            <li><a href="#">Perfil</a></li>
+        </ul>
+    </header>
+    <main class="main-content">
+        <h1 class="welcome-text">ESTADÍSTICAS</h1>
+        <p>Próximamente se mostrarán las estadísticas del sistema.</p>
+    </main>
+</body>
+</html>

--- a/RendicionDeGastos/MainApp/templates/MainApp/generar_informe.html
+++ b/RendicionDeGastos/MainApp/templates/MainApp/generar_informe.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% load static %}
+    <link rel="stylesheet" href="{% static 'MainApp/styles.css' %}">
+    <title>Generar Informe</title>
+</head>
+<body>
+    <header class="header">
+        <div class="logo">
+            <a href="{% url 'index' %}">INICIO</a>
+        </div>
+        <ul class="nav-links">
+            <li><a href="#">Usuario</a></li>
+            <li><a href="#">Perfil</a></li>
+        </ul>
+    </header>
+    <main class="main-content">
+        <h1 class="welcome-text">GENERAR INFORME</h1>
+        <p>Esta sección permitirá crear informes detallados.</p>
+    </main>
+</body>
+</html>

--- a/RendicionDeGastos/MainApp/templates/MainApp/index.html
+++ b/RendicionDeGastos/MainApp/templates/MainApp/index.html
@@ -25,8 +25,9 @@
         <h1 class="welcome-text">Bienvenido al Sistema de Rendiciones</h1>
         <div class="button-container">
             <a href="{% url 'trabajador' %}" class="primary-button">Vista Trabajador</a>
-            <a href="{% url 'contador' %}" class="primary-button">Vista Contador</a>
-            <a href="{% url 'jefe' %}" class="primary-button">Vista Jefe de Área</a>
+            <a href="{% url 'ingresador' %}" class="primary-button">Vista Ingresador</a>
+            <a href="{% url 'contador' %}" class="primary-button">Vista Validador</a>
+            <a href="{% url 'visualizador' %}" class="primary-button">Vista Visualizador</a>
         </div>
     </main>
 

--- a/RendicionDeGastos/MainApp/templates/MainApp/ingresador.html
+++ b/RendicionDeGastos/MainApp/templates/MainApp/ingresador.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% load static %}
+    <link rel="stylesheet" href="{% static 'MainApp/styles.css' %}">
+    <title>Ingresador</title>
+</head>
+<body>
+
+    <!-- Header -->
+    <header class="header">
+        <div class="logo">
+            <a href="{% url 'index' %}">INICIO</a>
+        </div>
+        <ul class="nav-links">
+            <li><a href="#">Usuario</a></li>
+            <li><a href="#">Perfil</a></li>
+        </ul>
+    </header>
+
+    <!-- Contenido principal -->
+    <main class="main-content">
+        <h1 class="welcome-text">BIENVENIDO, INGRESADOR</h1>
+        <div class="button-container">
+            <a href="{% url 'rendiciones_ingresadas' %}" class="primary-button">REVISION DE RENDICIONES</a>
+        </div>
+    </main>
+
+</body>
+</html>

--- a/RendicionDeGastos/MainApp/templates/MainApp/visualizador.html
+++ b/RendicionDeGastos/MainApp/templates/MainApp/visualizador.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% load static %}
+    <link rel="stylesheet" href="{% static 'MainApp/styles.css' %}">
+    <title>Visualizador</title>
+</head>
+<body>
+
+    <!-- Header -->
+    <header class="header">
+        <div class="logo">
+            <a href="{% url 'index' %}">INICIO</a>
+        </div>
+        <ul class="nav-links">
+            <li><a href="#">Usuario</a></li>
+            <li><a href="#">Perfil</a></li>
+        </ul>
+    </header>
+
+    <!-- Contenido principal -->
+    <main class="main-content">
+        <h1 class="welcome-text">BIENVENIDO, VISUALIZADOR</h1>
+        <div class="button-container">
+            <a href="{% url 'aprobadas' %}" class="primary-button">RENDICIONES APROBADAS</a>
+            <a href="{% url 'estadisticas' %}" class="primary-button">ESTADÍSTICAS</a>
+            <a href="{% url 'generar_informe' %}" class="primary-button">GENERAR INFORME</a>
+        </div>
+    </main>
+
+</body>
+</html>

--- a/RendicionDeGastos/MainApp/urls.py
+++ b/RendicionDeGastos/MainApp/urls.py
@@ -13,7 +13,11 @@ from .views import (
     resumen_rendicion,
     registrar_rendicion,
     crear_gasto,
-    aprobadas
+    aprobadas,
+    ingresador,
+    visualizador,
+    estadisticas,
+    generar_informe
 )
 
 urlpatterns = [
@@ -31,4 +35,8 @@ urlpatterns = [
     path('registrar-rendicion/', registrar_rendicion, name='registrar_rendicion'),
     path('crear-gasto/', crear_gasto, name='crear_gasto'),  # NUEVO
     path('aprobadas/', aprobadas, name='aprobadas'),  # FIX: usar la vista importada directamente
+    path('ingresador/', ingresador, name='ingresador'),
+    path('visualizador/', visualizador, name='visualizador'),
+    path('estadisticas/', estadisticas, name='estadisticas'),
+    path('generar-informe/', generar_informe, name='generar_informe'),
 ]

--- a/RendicionDeGastos/MainApp/views.py
+++ b/RendicionDeGastos/MainApp/views.py
@@ -153,3 +153,19 @@ def crear_gasto(request):
         return redirect('resumen_rendicion')
 
     return HttpResponse('Método no permitido', status=405)
+
+# Vista para el ingresador
+def ingresador(request):
+    return render(request, 'MainApp/ingresador.html')
+
+# Vista para el visualizador
+def visualizador(request):
+    return render(request, 'MainApp/visualizador.html')
+
+# Vista de estadísticas
+def estadisticas(request):
+    return render(request, 'MainApp/estadisticas.html')
+
+# Vista para generar informe
+def generar_informe(request):
+    return render(request, 'MainApp/generar_informe.html')


### PR DESCRIPTION
## Summary
- expand index with visualizador and ingresador links
- add new templates for ingresador, visualizador and placeholder pages
- show comments and files in aprobadas list
- wire new views and routes

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68437486b97c8328920f43a74a15706a