### PR TITLE
Add multi-phase validation for renditions

### DIFF
--- a/RendicionDeGastos/MainApp/models.py
+++ b/RendicionDeGastos/MainApp/models.py
@@ -2,9 +2,24 @@ from django.db import models
 
 # Modelo para representar una Rendición
 class Rendicion(models.Model):
+    """Representa una rendición de gastos."""
+
+    ESTADO_INGRESADA = 'Ingresada'
+    ESTADO_PENDIENTE = 'Pendiente'
+    ESTADO_APROBADO = 'Aprobado'
+    ESTADO_RECHAZADO = 'Rechazado'
+
+    ESTADOS_CHOICES = [
+        (ESTADO_INGRESADA, 'Ingresada'),
+        (ESTADO_PENDIENTE, 'Pendiente'),
+        (ESTADO_APROBADO, 'Aprobado'),
+        (ESTADO_RECHAZADO, 'Rechazado'),
+    ]
+
     fecha_creacion = models.DateField(auto_now_add=True)  # Fecha en la que se crea la rendición
     total = models.DecimalField(max_digits=10, decimal_places=2, default=0)  # Monto total de la rendición
-    estado = models.CharField(max_length=20, default='En progreso')  # Estado de la rendición (Ej: En progreso, Confirmada)
+    # Estado de la rendición (controla las fases Ingreso/Validación)
+    estado = models.CharField(max_length=20, choices=ESTADOS_CHOICES, default=ESTADO_INGRESADA)
 
     def __str__(self):
         return f"Rendición {self.id} - {self.estado}"

--- a/RendicionDeGastos/MainApp/static/MainApp/rendiciones.css
+++ b/RendicionDeGastos/MainApp/static/MainApp/rendiciones.css
@@ -161,6 +161,7 @@ body {
     padding: 5px 10px;
     cursor: pointer;
     border-radius: 5px;
+    margin-left: 5px;
 }
 
 .confirm-button:hover {

--- a/RendicionDeGastos/MainApp/static/MainApp/rendiciones.css
+++ b/RendicionDeGastos/MainApp/static/MainApp/rendiciones.css
@@ -121,6 +121,11 @@ body {
     background-color: #ffc107;
     color: #000;
 }
+
+.rendicion-estado.ingresada {
+    background-color: #17a2b8;
+    color: #fff;
+}
 /*--------------------------------------------------*/
 .pagination {
     text-align: center;
@@ -147,5 +152,18 @@ body {
     font-size: 16px;
     color: white;
     margin: 0 10px;
+}
+
+.confirm-button {
+    background-color: #0d6efd;
+    color: white;
+    border: none;
+    padding: 5px 10px;
+    cursor: pointer;
+    border-radius: 5px;
+}
+
+.confirm-button:hover {
+    opacity: 0.8;
 }
 

--- a/RendicionDeGastos/MainApp/templates/MainApp/detalle_rendicion.html
+++ b/RendicionDeGastos/MainApp/templates/MainApp/detalle_rendicion.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% load static %}
+    <link rel="stylesheet" href="{% static 'MainApp/rendiciones.css' %}">
+    <title>Detalle Rendición</title>
+</head>
+<body>
+    <!-- Header -->
+    <header class="header">
+        <div class="logo">
+            <a href="{% url 'index' %}">INICIO</a>
+        </div>
+        <ul class="nav-links">
+            <li><a href="#">Usuario</a></li>
+            <li><a href="#">Perfil</a></li>
+        </ul>
+    </header>
+
+    <main class="main-content">
+        <h1 class="welcome-text">Rendición {{ rendicion.id }}</h1>
+        <div class="rendicion-list">
+            {% for gasto in gastos %}
+                <div class="rendicion-item">
+                    <span class="rendicion-nombre">{{ gasto.tipo }} - ${{ gasto.monto }}</span>
+                    <span>{{ gasto.descripcion }}</span>
+                </div>
+            {% endfor %}
+            <div class="rendicion-item">
+                <span class="rendicion-nombre">TOTAL</span>
+                <span>${{ total }}</span>
+            </div>
+        </div>
+        <form method="POST" style="margin-top:20px;">
+            {% csrf_token %}
+            <button type="submit" class="confirm-button">Confirmar rendición</button>
+        </form>
+        <a href="{% url 'rendiciones_ingresadas' %}" class="pagination-button" style="margin-top:20px;">Volver</a>
+    </main>
+</body>
+</html>

--- a/RendicionDeGastos/MainApp/templates/MainApp/rendiciones_ingresadas.html
+++ b/RendicionDeGastos/MainApp/templates/MainApp/rendiciones_ingresadas.html
@@ -27,11 +27,14 @@
                 <div class="rendicion-item">
                     <span class="rendicion-nombre">Rendición {{ rendicion.id }}</span>
                     <span class="rendicion-estado {{ rendicion.estado|lower }}">{{ rendicion.estado }}</span>
-                    <form method="POST" style="display:inline;">
-                        {% csrf_token %}
-                        <input type="hidden" name="rendicion_id" value="{{ rendicion.id }}">
-                        <button type="submit" class="confirm-button">Confirmar</button>
-                    </form>
+                    <div>
+                        <a href="{% url 'detalle_rendicion' rendicion.id %}" class="pagination-button">Detalles</a>
+                        <form method="POST" style="display:inline;">
+                            {% csrf_token %}
+                            <input type="hidden" name="rendicion_id" value="{{ rendicion.id }}">
+                            <button type="submit" class="confirm-button">Confirmar</button>
+                        </form>
+                    </div>
                 </div>
             {% endfor %}
         </div>

--- a/RendicionDeGastos/MainApp/templates/MainApp/rendiciones_ingresadas.html
+++ b/RendicionDeGastos/MainApp/templates/MainApp/rendiciones_ingresadas.html
@@ -26,7 +26,12 @@
             {% for rendicion in page_obj.object_list %}
                 <div class="rendicion-item">
                     <span class="rendicion-nombre">Rendición {{ rendicion.id }}</span>
-                    <span class="rendicion-estado">{{ rendicion.estado }}</span>
+                    <span class="rendicion-estado {{ rendicion.estado|lower }}">{{ rendicion.estado }}</span>
+                    <form method="POST" style="display:inline;">
+                        {% csrf_token %}
+                        <input type="hidden" name="rendicion_id" value="{{ rendicion.id }}">
+                        <button type="submit" class="confirm-button">Confirmar</button>
+                    </form>
                 </div>
             {% endfor %}
         </div>

--- a/RendicionDeGastos/MainApp/urls.py
+++ b/RendicionDeGastos/MainApp/urls.py
@@ -17,7 +17,8 @@ from .views import (
     ingresador,
     visualizador,
     estadisticas,
-    generar_informe
+    generar_informe,
+    detalle_rendicion
 )
 
 urlpatterns = [
@@ -39,4 +40,5 @@ urlpatterns = [
     path('visualizador/', visualizador, name='visualizador'),
     path('estadisticas/', estadisticas, name='estadisticas'),
     path('generar-informe/', generar_informe, name='generar_informe'),
+    path('rendicion/<int:rendicion_id>/', detalle_rendicion, name='detalle_rendicion'),
 ]

--- a/RendicionDeGastos/MainApp/views.py
+++ b/RendicionDeGastos/MainApp/views.py
@@ -116,6 +116,30 @@ def rendiciones_ingresadas(request):
 
     return render(request, 'MainApp/rendiciones_ingresadas.html', {'page_obj': page_obj})
 
+# Vista para ver los detalles de una rendición ingresada
+def detalle_rendicion(request, rendicion_id):
+    """Muestra los gastos asociados y permite confirmar la rendición."""
+
+    rendicion = Rendicion.objects.get(id=rendicion_id)
+    gastos = Gasto.objects.filter(rendicion=rendicion)
+
+    if request.method == 'POST':
+        if rendicion.estado == Rendicion.ESTADO_INGRESADA:
+            rendicion.estado = Rendicion.ESTADO_PENDIENTE
+            rendicion.save()
+        return redirect('rendiciones_ingresadas')
+
+    total = sum(gasto.monto for gasto in gastos)
+    return render(
+        request,
+        'MainApp/detalle_rendicion.html',
+        {
+            'rendicion': rendicion,
+            'gastos': gastos,
+            'total': total,
+        },
+    )
+
 # Vista para mostrar solo las rendiciones aprobadas
 def aprobadas(request):
     rendiciones_aprobadas = Rendicion.objects.filter(

--- a/RendicionDeGastos/MainApp/views.py
+++ b/RendicionDeGastos/MainApp/views.py
@@ -57,10 +57,11 @@ def resumen_rendicion(request):
 # Vista para registrar la rendición final
 def registrar_rendicion(request):
     if request.method == 'POST':
-        # Crear una nueva rendición
+        # Crear una nueva rendición ingresada por el trabajador
         rendicion = Rendicion.objects.create(
-            estado='Pendiente',  # Estado inicial
-            total=0.0  # Este valor se actualizará después
+            # El primer estado es "Ingresada"
+            estado=Rendicion.ESTADO_INGRESADA,
+            total=0.0,  # Este valor se actualizará después
         )
 
         # Asociar los gastos temporales a esta rendición
@@ -92,7 +93,22 @@ def exito(request):
 
 # Vista para mostrar rendiciones ingresadas con paginación
 def rendiciones_ingresadas(request):
-    rendiciones = Rendicion.objects.all().order_by('id')  # Orden ascendente
+    """Lista y permite confirmar las rendiciones ingresadas."""
+
+    if request.method == 'POST':
+        # El ingresador confirma una rendición para pasarla a revisión
+        rendicion_id = request.POST.get('rendicion_id')
+        if rendicion_id:
+            rendicion = Rendicion.objects.get(id=rendicion_id)
+            if rendicion.estado == Rendicion.ESTADO_INGRESADA:
+                rendicion.estado = Rendicion.ESTADO_PENDIENTE
+                rendicion.save()
+        return redirect('rendiciones_ingresadas')
+
+    # El ingresador sólo visualiza las rendiciones ingresadas
+    rendiciones = Rendicion.objects.filter(
+        estado=Rendicion.ESTADO_INGRESADA
+    ).order_by('id')
     paginator = Paginator(rendiciones, 6)  # 6 rendiciones por página
 
     page_number = request.GET.get('page')  # Obtén el número de página de la URL
@@ -102,7 +118,9 @@ def rendiciones_ingresadas(request):
 
 # Vista para mostrar solo las rendiciones aprobadas
 def aprobadas(request):
-    rendiciones_aprobadas = Rendicion.objects.filter(estado='Aprobado').order_by('id')  # Solo aprobadas en orden ascendente
+    rendiciones_aprobadas = Rendicion.objects.filter(
+        estado=Rendicion.ESTADO_APROBADO
+    ).order_by('id')
     return render(request, 'MainApp/aprobadas.html', {'rendiciones': rendiciones_aprobadas})
 
 # Vista para gestionar reembolsos
@@ -114,16 +132,18 @@ def gestion_reembolsos(request):
         # Buscar la rendición y actualizar su estado
         rendicion = Rendicion.objects.get(id=rendicion_id)
         if accion == 'aprobar':
-            rendicion.estado = 'Aprobado'
+            rendicion.estado = Rendicion.ESTADO_APROBADO
         elif accion == 'rechazar':
-            rendicion.estado = 'Rechazado'
+            rendicion.estado = Rendicion.ESTADO_RECHAZADO
         rendicion.save()
 
         # Redirigir a la misma página para reflejar los cambios
         return redirect('gestion_reembolsos')
 
     # Obtener todas las rendiciones pendientes
-    rendiciones_pendientes = Rendicion.objects.filter(estado='Pendiente')
+    rendiciones_pendientes = Rendicion.objects.filter(
+        estado=Rendicion.ESTADO_PENDIENTE
+    )
 
     # Asegurarse de que todas las rendiciones tengan su total correctamente calculado
     for rendicion in rendiciones_pendientes:


### PR DESCRIPTION
## Summary
- introduce explicit states for renditions
- show only pending renditions to the ingresador
- keep validador logic using the new states
- implement confirmation of ingresada renditions

## Testing
- `python RendicionDeGastos/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6856e463b0d883289c3322f35d513467